### PR TITLE
Fix space char `? `, formatted incorrectly

### DIFF
--- a/emms-mode-line-cycle.el
+++ b/emms-mode-line-cycle.el
@@ -111,13 +111,13 @@ Its function returns a stirng."
   "Substring STR with `emms-mode-line-cycle-max-width'.
 WIDTH is string width."
   (truncate-string-to-width
-   str (or width emms-mode-line-cycle-max-width) 0 ?))
+   str (or width emms-mode-line-cycle-max-width) 0 (string-to-char " ")))
 
 (defun emms-mode-line-cycle--make-title-queue (title)
   "Return a queue of TITLE."
   (let ((char-ls (nconc (string-to-list title)
                         (make-list emms-mode-line-cycle-additional-space-num
-                                   ?)))
+                                   (string-to-char " "))))
         (queue (cons nil nil)))
     (setcar queue (last (setcdr queue char-ls)))
     queue))


### PR DESCRIPTION
emacs-lisp-mode or another minor mode is messing out with formatting
`(... ? )` => `(... ?)`, the space after is removed while it had a
semantic meaning.